### PR TITLE
Fix: inject ImplicitUsings default for .NET projects

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -72,6 +72,23 @@ if [[ -n "$OSC_ACCESS_TOKEN" && -n "$CONFIG_SVC" ]]; then
   fi
 fi
 
+# ---- Build defaults ----
+# Inject Directory.Build.props to enable ImplicitUsings by default.
+# The dotnet SDK does NOT default ImplicitUsings to 'enable' — only the
+# 'dotnet new' templates set it explicitly. Without this, minimal API code
+# (WebApplication, Environment, etc.) fails to compile. The Condition ensures
+# projects that explicitly set ImplicitUsings are not overridden.
+if [[ ! -f "$BUILD_DIR/Directory.Build.props" ]]; then
+  cat > "$BUILD_DIR/Directory.Build.props" << 'DBPROPS'
+<Project>
+  <PropertyGroup Condition="'$(ImplicitUsings)' == ''">
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>
+DBPROPS
+  echo "[BUILD] Injected default ImplicitUsings=enable (no Directory.Build.props found)"
+fi
+
 # ---- Build phase ----
 cd "$BUILD_DIR"
 mkdir -p /app/published


### PR DESCRIPTION
## Summary
- Injects a `Directory.Build.props` before build that defaults `ImplicitUsings` to `enable` when the project doesn't set it
- Without this, any .NET project not created via `dotnet new` (or manually missing the property) fails with `CS0103: WebApplication does not exist`
- The `Condition` ensures projects that explicitly set `ImplicitUsings` (to enable or disable) are not overridden
- Projects with an existing `Directory.Build.props` are also left untouched

## Root cause
The .NET SDK does **not** default `ImplicitUsings` to `enable`. Only the `dotnet new` templates include it explicitly in the generated `.csproj`. This is a common gotcha since every tutorial assumes it's enabled.

## Test plan
- [x] Verified: project without `ImplicitUsings` now builds successfully
- [x] Verified: project with `ImplicitUsings=enable` still works (condition skips)
- [x] Verified: project with `ImplicitUsings=disable` + explicit usings still works (condition skips)
- [x] Verified: project with existing `Directory.Build.props` is not overwritten

🤖 Generated with [Claude Code](https://claude.ai/code)