### PR TITLE
feat: write .commit-info.json after git clone

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -17,15 +17,30 @@ trap cleanup EXIT
 write_commit_info() {
   local repo_dir="$1"
   if [ -d "$repo_dir/.git" ]; then
-    git -C "$repo_dir" log -5 --format='{"sha":"%H","shortSha":"%h","message":"%s","author":"%an","date":"%aI"}' \
-      | jq -s '{
-          sha: .[0].sha,
-          shortSha: .[0].shortSha,
-          message: .[0].message,
-          author: .[0].author,
-          date: .[0].date,
-          recentCommits: .
-        }' > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    local sha shortSha msg author date recentCommits
+    sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null) || return 0
+    shortSha=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null) || return 0
+    msg=$(git -C "$repo_dir" log -1 --format='%s' 2>/dev/null) || return 0
+    author=$(git -C "$repo_dir" log -1 --format='%an' 2>/dev/null) || return 0
+    date=$(git -C "$repo_dir" log -1 --format='%aI' 2>/dev/null) || return 0
+    recentCommits=$(git -C "$repo_dir" log -5 --format='%H' 2>/dev/null | while read -r c_sha; do
+      jq -n \
+        --arg sha "$c_sha" \
+        --arg shortSha "$(git -C "$repo_dir" rev-parse --short "$c_sha" 2>/dev/null)" \
+        --arg message "$(git -C "$repo_dir" log -1 --format='%s' "$c_sha" 2>/dev/null)" \
+        --arg author "$(git -C "$repo_dir" log -1 --format='%an' "$c_sha" 2>/dev/null)" \
+        --arg date "$(git -C "$repo_dir" log -1 --format='%aI' "$c_sha" 2>/dev/null)" \
+        '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date}'
+    done | jq -s '.' 2>/dev/null) || recentCommits='[]'
+    jq -n \
+      --arg sha "$sha" \
+      --arg shortSha "$shortSha" \
+      --arg message "$msg" \
+      --arg author "$author" \
+      --arg date "$date" \
+      --argjson recentCommits "$recentCommits" \
+      '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date,recentCommits:$recentCommits}' \
+      > "$repo_dir/.commit-info.json" 2>/dev/null || true
     echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
   fi
 }

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -13,6 +13,23 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Write commit metadata to a well-known file for platform visibility
+write_commit_info() {
+  local repo_dir="$1"
+  if [ -d "$repo_dir/.git" ]; then
+    git -C "$repo_dir" log -5 --format='{"sha":"%H","shortSha":"%h","message":"%s","author":"%an","date":"%aI"}' \
+      | jq -s '{
+          sha: .[0].sha,
+          shortSha: .[0].shortSha,
+          message: .[0].message,
+          author: .[0].author,
+          date: .[0].date,
+          recentCommits: .
+        }' > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
+  fi
+}
+
 # ---- Clone phase ----
 SOURCE_URL="${SOURCE_URL:-$GITHUB_URL}"
 if [[ -z "$SOURCE_URL" ]]; then
@@ -48,6 +65,8 @@ if [[ -n "$BRANCH" ]]; then
 else
   git clone --depth 1 "$SOURCE_URL" "$WORK_DIR"
 fi
+
+write_commit_info "$WORK_DIR"
 
 # ---- Sub-path support ----
 BUILD_DIR="$WORK_DIR"


### PR DESCRIPTION
## Summary

- Adds `write_commit_info()` function to `scripts/docker-entrypoint.sh`
- After git clone completes, writes `.commit-info.json` to `WORK_DIR` (`/usercontent/app`)
- The JSON contains `sha`, `shortSha`, `message`, `author`, `date`, and `recentCommits` (up to 5 entries)
- Uses `jq -s` to aggregate the log lines; the entire call is guarded with `|| true` so clone failures or missing jq never block the build
- Logs a one-liner (`shortSha - message`) to stdout for quick diagnostics

Closes #5

## Test plan

- [ ] Build the Docker image locally and run a container with a valid `SOURCE_URL`; confirm `.commit-info.json` appears in `/usercontent/app` with the expected fields
- [ ] Confirm build continues normally after the function runs (no regressions)
- [ ] Verify the file is absent when `--depth 1` clone fails (error path exits before `write_commit_info` is reached)

🤖 Generated with [Claude Code](https://claude.ai/code)