### PR TITLE
Strip embedded credentials from GIT_HOST to prevent PAT leak

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -60,18 +60,22 @@ if [[ "$SOURCE_URL" == *"#"* ]]; then
   SOURCE_URL="${SOURCE_URL%%#*}"
 fi
 
-# Inject token if provided
+# Always parse host, path, and protocol from SOURCE_URL so that they are
+# available for the credential-scrub step regardless of which auth path is taken.
+GIT_HOST="${SOURCE_URL#*://}"
+GIT_HOST="${GIT_HOST%%/*}"   # keep only the hostname (may include user:pass@ for Gitea)
+# Variant with any embedded credentials stripped — used for the persisted
+# remote URL so that PATs never leak into .git/config.
+# When SOURCE_URL has no credentials this is identical to GIT_HOST.
+GIT_HOST_PUBLIC="${GIT_HOST##*@}"
+GIT_PATH="/${SOURCE_URL#*://*/}"
+[[ "/${SOURCE_URL}" == "${GIT_PATH}" ]] && GIT_PATH="/"
+PROTOCOL="${SOURCE_URL%%://*}"
+
+# Inject token if provided (GitHub / GIT_TOKEN path)
 GIT_TOKEN="${GIT_TOKEN:-$GITHUB_TOKEN}"
 if [[ -n "$GIT_TOKEN" ]]; then
-  GIT_HOST="${SOURCE_URL#*://}"
-  GIT_HOST="${GIT_HOST%%/*}"
-  GIT_PATH="/${SOURCE_URL#*://*/}"
-  [[ "/${SOURCE_URL}" == "${GIT_PATH}" ]] && GIT_PATH="/"
-  if [[ "$SOURCE_URL" == *"#"* ]]; then
-    GIT_PATH="${GIT_PATH%%#*}"
-  fi
-  PROTOCOL="${SOURCE_URL%%://*}"
-  SOURCE_URL="${PROTOCOL}://${GIT_TOKEN}@${GIT_HOST}${GIT_PATH}"
+  SOURCE_URL="${PROTOCOL}://${GIT_TOKEN}@${GIT_HOST_PUBLIC}${GIT_PATH}"
 fi
 
 rm -rf "$WORK_DIR"
@@ -81,10 +85,10 @@ else
   git clone --depth 1 "$SOURCE_URL" "$WORK_DIR"
 fi
 
-# Scrub PAT from origin remote — token must not persist to .git/config
-if [[ -n "$GIT_TOKEN" ]]; then
-  git -C "$WORK_DIR" remote set-url origin "${PROTOCOL}://${GIT_HOST}${GIT_PATH}"
-fi
+# Scrub credentials from origin remote — tokens and embedded credentials must
+# not persist to .git/config. This covers both the GIT_TOKEN path and the
+# Gitea embedded-credential path (https://user:pass@host/path).
+git -C "$WORK_DIR" remote set-url origin "${PROTOCOL}://${GIT_HOST_PUBLIC}${GIT_PATH}"
 
 write_commit_info "$WORK_DIR"
 

--- a/tests/test-entrypoint-credential-scrub.sh
+++ b/tests/test-entrypoint-credential-scrub.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# tests/test-entrypoint-credential-scrub.sh
+#
+# Shell regression tests for the credential-scrub fix in scripts/docker-entrypoint.sh.
+#
+# Background:
+#   When SOURCE_URL embeds credentials (https://user:pass@host/path.git), the
+#   pattern used by Gitea-backed apps, the host extraction
+#       GIT_HOST="${SOURCE_URL#*://}"; GIT_HOST="${GIT_HOST%%/*}"
+#   yields "user:pass@host" — i.e. credentials remain in GIT_HOST.
+#
+#   The clone then persisted the credentialed URL into .git/config because the
+#   original "scrub" line was guarded by `if [[ -n "$GIT_TOKEN" ]]` and was
+#   therefore skipped entirely for Gitea apps (which embed credentials in
+#   SOURCE_URL directly and do not set GIT_TOKEN).
+#
+# Fix (this PR):
+#   Parse GIT_HOST / GIT_PATH / PROTOCOL unconditionally (before the GIT_TOKEN
+#   block). Introduce GIT_HOST_PUBLIC="${GIT_HOST##*@}" — a sanitized variant
+#   used for the persisted remote URL. Remove the GIT_TOKEN guard from the
+#   `remote set-url` scrub so it always runs. When SOURCE_URL has no
+#   credentials, GIT_HOST_PUBLIC == GIT_HOST and behaviour is unchanged.
+#
+# These tests grep the entrypoint to assert the fix has not regressed.
+
+ENTRYPOINT="scripts/docker-entrypoint.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: GIT_HOST_PUBLIC is derived from GIT_HOST with embedded creds stripped
+# ---------------------------------------------------------------------------
+if grep -qE 'GIT_HOST_PUBLIC="\$\{GIT_HOST##\*@\}"' "$ENTRYPOINT"; then
+  pass "GIT_HOST_PUBLIC strips user:pass@ from GIT_HOST"
+else
+  fail "GIT_HOST_PUBLIC assignment is missing or does not strip embedded creds"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: persisted remote URL uses the scrubbed host
+# ---------------------------------------------------------------------------
+if grep -qF 'git -C "$WORK_DIR" remote set-url origin "${PROTOCOL}://${GIT_HOST_PUBLIC}${GIT_PATH}"' "$ENTRYPOINT"; then
+  pass "remote set-url uses GIT_HOST_PUBLIC (credentials removed from .git/config)"
+else
+  fail "remote set-url still uses GIT_HOST — credentials would leak into .git/config"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: remote set-url is unconditional — not guarded by GIT_TOKEN
+#
+# The scrub must run for both the GIT_TOKEN path and the Gitea
+# embedded-credential path. An `if [[ -n "$GIT_TOKEN" ]]` guard around the
+# set-url means Gitea apps never have their .git/config scrubbed.
+# ---------------------------------------------------------------------------
+guarded=$(awk '/if \[\[ -n.*GIT_TOKEN/,/fi/' "$ENTRYPOINT" | grep 'remote set-url' || true)
+if [ -z "$guarded" ]; then
+  pass "remote set-url is not guarded by GIT_TOKEN (unconditional scrub)"
+else
+  fail "remote set-url is still inside a GIT_TOKEN guard — Gitea credentials would leak: $guarded"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: no surviving line that persists the unscrubbed GIT_HOST
+# ---------------------------------------------------------------------------
+unsafe_persist=$(grep -nE 'remote set-url origin "https://\$\{GIT_HOST\}\$\{GIT_PATH\}"' "$ENTRYPOINT" || true)
+if [ -z "$unsafe_persist" ]; then
+  pass "no remote set-url persists the unscrubbed GIT_HOST"
+else
+  fail "remote set-url still persists unscrubbed GIT_HOST: $unsafe_persist"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: behavioral verification — run the relevant fragment in a sandbox
+#
+# Source the host-parsing logic with a Gitea-style SOURCE_URL and assert that
+# GIT_HOST_PUBLIC has no '@' while GIT_HOST does. This catches regressions
+# where the parameter expansion is changed in a way that defeats the strip.
+# ---------------------------------------------------------------------------
+sandbox=$(bash -c '
+  SOURCE_URL="https://oscadmin:abc123def@example.git.host/owner/repo.git"
+  GIT_HOST="${SOURCE_URL#*://}"
+  GIT_HOST="${GIT_HOST%%/*}"
+  GIT_HOST_PUBLIC="${GIT_HOST##*@}"
+  echo "GIT_HOST=$GIT_HOST"
+  echo "GIT_HOST_PUBLIC=$GIT_HOST_PUBLIC"
+')
+
+if echo "$sandbox" | grep -q '^GIT_HOST=oscadmin:abc123def@example.git.host$' && \
+   echo "$sandbox" | grep -q '^GIT_HOST_PUBLIC=example.git.host$'; then
+  pass "host-parsing on a Gitea-style URL strips creds in GIT_HOST_PUBLIC only"
+else
+  fail "host-parsing sandbox produced unexpected output: $sandbox"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: behavioral verification — credential-less URL is unchanged
+# ---------------------------------------------------------------------------
+sandbox_plain=$(bash -c '
+  SOURCE_URL="https://github.com/owner/repo.git"
+  GIT_HOST="${SOURCE_URL#*://}"
+  GIT_HOST="${GIT_HOST%%/*}"
+  GIT_HOST_PUBLIC="${GIT_HOST##*@}"
+  echo "GIT_HOST=$GIT_HOST"
+  echo "GIT_HOST_PUBLIC=$GIT_HOST_PUBLIC"
+')
+
+if echo "$sandbox_plain" | grep -q '^GIT_HOST=github.com$' && \
+   echo "$sandbox_plain" | grep -q '^GIT_HOST_PUBLIC=github.com$'; then
+  pass "host-parsing on a credential-less URL is a no-op (GIT_HOST_PUBLIC == GIT_HOST)"
+else
+  fail "credential-less host-parsing produced unexpected output: $sandbox_plain"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: behavioral verification — GIT_TOKEN path uses GIT_HOST_PUBLIC
+#
+# When GIT_TOKEN is set, the injected URL must use GIT_HOST_PUBLIC (not
+# GIT_HOST which might already contain embedded creds from SOURCE_URL).
+# ---------------------------------------------------------------------------
+if grep -qF '${GIT_TOKEN}@${GIT_HOST_PUBLIC}' "$ENTRYPOINT"; then
+  pass "GIT_TOKEN injection uses GIT_HOST_PUBLIC (no double-embedding of creds)"
+else
+  fail "GIT_TOKEN injection does not reference GIT_HOST_PUBLIC"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR #8 scrubbed the `GIT_TOKEN`-injected credential from `.git/config`, but missed the **Gitea embedded-credential path**: when `SOURCE_URL` contains `https://oscadmin:TOKEN@host/path` and `GIT_TOKEN` is unset, the `remote set-url` scrub was guarded by `if [[ -n "$GIT_TOKEN" ]]` and therefore **never ran**. The Gitea PAT persisted verbatim in `.git/config` for the pod's lifetime.

This matches the fix already landed in web-runner [PR #37](https://github.com/Eyevinn/web-runner/pull/37).

## Both leak vectors (from web-runner PR #37 context)

1. **Stdout / Loki** (dotnet-runner had no `echo "cloning..."` line, so this vector was absent)
2. **`/usercontent/app/.git/config`** — `git remote set-url origin` was only called when `GIT_TOKEN` was set. For Gitea apps the guard was never true, leaving the credentialed URL on disk.

## Changes

**`scripts/docker-entrypoint.sh`**

- Parse `GIT_HOST` / `GIT_PATH` / `PROTOCOL` unconditionally (before the `GIT_TOKEN` block) so they are available for the unconditional scrub step.
- Introduce `GIT_HOST_PUBLIC="${GIT_HOST##*@}"` — a sanitized variant with any embedded `user:pass@` stripped.
- Use `GIT_HOST_PUBLIC` in the `GIT_TOKEN` injection URL (prevents double-embedding if `SOURCE_URL` already had creds).
- Remove the `if [[ -n "$GIT_TOKEN" ]]` guard from `remote set-url`, making the scrub unconditional.

**`tests/test-entrypoint-credential-scrub.sh`** (new)

7-assertion shell test covering:
- `GIT_HOST_PUBLIC` strips `user:pass@` (static grep)
- `remote set-url` uses `GIT_HOST_PUBLIC` (static grep)
- `remote set-url` is not guarded by `GIT_TOKEN` (static grep)
- No surviving `${GIT_HOST}` in `remote set-url` (static grep)
- Gitea-style URL parsing (sandbox execution)
- Credential-less URL is a no-op (sandbox execution)
- `GIT_TOKEN` injection uses `GIT_HOST_PUBLIC` (static grep)

## Auth path coverage

| Path | Before | After |
|---|---|---|
| GitHub / `GIT_TOKEN` | Scrubbed (PAT removed) | Scrubbed (uses `GIT_HOST_PUBLIC`) |
| Gitea embedded creds | **Leaked** into `.git/config` | Scrubbed |
| Public repo (no creds) | No-op | No-op (`GIT_HOST_PUBLIC == GIT_HOST`) |

## GitHub flows unaffected

GitHub-hosted apps use `GIT_TOKEN` (injected separately). The `GIT_HOST_PUBLIC` computed from a plain `github.com` URL is identical to `GIT_HOST`, so the behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)